### PR TITLE
Remove/Replace stale dependecies

### DIFF
--- a/src/entities/core.lisp
+++ b/src/entities/core.lisp
@@ -2,7 +2,7 @@
   (:use #:cl)
   (:import-from #:cl-telegram-bot/utils
                 #:make-keyword)
-  (:import-from #:cl-arrows
+  (:import-from #:arrows
                 #:->)
   (:nicknames #:cl-telegram-bot/entities)
   (:export

--- a/src/network.lisp
+++ b/src/network.lisp
@@ -5,8 +5,6 @@
                 #:obfuscate)
   (:import-from #:cl-telegram-bot/bot
                 #:get-endpoint)
-  (:import-from #:trivial-timeout
-                #:with-timeout)
   (:export
    #:make-request
    #:request-error))

--- a/src/telegram-call.lisp
+++ b/src/telegram-call.lisp
@@ -1,6 +1,6 @@
 (defpackage #:cl-telegram-bot/telegram-call
   (:use #:cl)
-  (:import-from #:cl-arrows
+  (:import-from #:arrows
                 #:->)
   (:import-from #:cl-telegram-bot/utils
                 #:make-json-keyword)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -1,6 +1,6 @@
 (defpackage #:cl-telegram-bot/utils
   (:use #:cl)
-  (:import-from #:cl-arrows
+  (:import-from #:arrows
                 #:->)
   (:import-from #:cl-ppcre
                 #:regex-replace)


### PR DESCRIPTION
New version of dexador supports read-timeout & connect-timeout keyword arguments
in function "post".