### PR TITLE
Enable send-message to work.

### DIFF
--- a/src/bot.lisp
+++ b/src/bot.lisp
@@ -8,7 +8,6 @@
    #:access
    #:set-webhook
    #:get-webhook-info
-   #:send-message
    #:forward-message
    #:send-photo
    #:send-audio

--- a/src/chat.lisp
+++ b/src/chat.lisp
@@ -9,7 +9,6 @@
   (:import-from #:alexandria
                 #:ensure-symbol)
   (:export
-   #:make-chat
    #:get-raw-data
    #:get-chat-id
    #:get-username

--- a/src/message.lisp
+++ b/src/message.lisp
@@ -17,6 +17,7 @@
   (:import-from #:cl-telegram-bot/utils
                 #:def-telegram-call)
   (:export
+   #:send-message
    #:make-message
    #:get-text
    #:get-raw-data


### PR DESCRIPTION
As per the discussion with svetlyak40wt on the gitter discussion platform.

1. Make sure send-message is exported from the cl-telegram-bot/message package instead of
cl-telegram-bot/bot  (I see some other functions also need such refactoring.

2. remove export of the make-chat function because now it waits some internal plist with
response from telegram server.

Further discussion of the next steps is in Issue #7 .