### PR TITLE
src/message: Add delete-message binding.

### DIFF
--- a/src/message.lisp
+++ b/src/message.lisp
@@ -19,6 +19,7 @@
   (:export
    #:send-message
    #:delete-message
+   #:forward-message
    #:make-message
    #:get-text
    #:get-raw-data
@@ -121,19 +122,16 @@
 ;;              `(:reply_to_message_id ,reply-to-message-id)))))
 ;;     (make-request bot "sendMessage" options)))
 
+(defun forward-message (bot chat from-chat message &key disable-notification)
+  "https://core.telegram.org/bots/api#forwardmessage"
+  (let ((options
+         (list :|chat_id| (get-chat-id chat)
+               :|from_chat_id| (get-chat-id from-chat)
+               :|message_id| (get-message-id message))))
+    (when disable-notification (nconc options `((:|disable_notification| . ,disable-notification))))
+    (make-request bot "forwardMessage" options)))
 
 ;; TODO: refactor
-
-;; (defun forward-message (b chat-id from-chat-id message-id &key disable-notification)
-;;   "https://core.telegram.org/bots/api#forwardmessage"
-;;   (let ((options
-;;          (list
-;;           (cons :chat_id chat-id)
-;;           (cons :from_chat_id from-chat-id)
-;;           (cons :message_id message-id))))
-;;     (when disable-notification (nconc options `((:disable_notification . ,disable-notification))))
-;;     (make-request b "forwardMessage" options)))
-
 
 ;; (defun edit-message-text (b text &key chat-id message-id inline-message-id parse-mode disable-web-page-preview reply-markup)
 ;;   "https://core.telegram.org/bots/api#editmessagetext"

--- a/src/message.lisp
+++ b/src/message.lisp
@@ -18,6 +18,7 @@
                 #:def-telegram-call)
   (:export
    #:send-message
+   #:delete-message
    #:make-message
    #:get-text
    #:get-raw-data
@@ -38,7 +39,9 @@
 
 
 (defclass message ()
-  ((text :initarg :text
+  ((id :initarg :id
+       :reader get-message-id)
+   (text :initarg :text
          :reader get-text)
    (chat :initarg :chat
          :reader get-chat)
@@ -51,6 +54,7 @@
 
 (defun make-message (data)
   (let ((message (make-instance 'message
+                                :id (getf data :|message_id|)
                                 :text (getf data :|text|)
                                 :chat (make-chat (getf data :|chat|))
                                 :raw-data data)))
@@ -163,13 +167,12 @@
 ;;     (when reply-markup (nconc options `((:reply_markup . ,reply-markup))))
 ;;     (make-request b "editMessageReplyMarkup" options)))
 
-;; (defun delete-message (b chat-id message-id)
-;;   "https://core.telegram.org/bots/api#deletemessage"
-;;   (let ((options
-;;          (list
-;;           (cons :chat_id chat-id)
-;;           (cons :message_id message-id))))
-;;     (make-request b "deleteMessage" options)))
+(defun delete-message (bot chat message)
+  "https://core.telegram.org/bots/api#deletemessage"
+  (let ((options
+         (list :|chat_id| (get-chat-id chat)
+               :|message_id| (get-message-id message))))
+    (make-request bot "deleteMessage" options)))
 
 
 (define-condition reply-immediately ()

--- a/src/message.lisp
+++ b/src/message.lisp
@@ -125,10 +125,11 @@
 (defun forward-message (bot chat from-chat message &key disable-notification)
   "https://core.telegram.org/bots/api#forwardmessage"
   (let ((options
-         (list :|chat_id| (get-chat-id chat)
-               :|from_chat_id| (get-chat-id from-chat)
-               :|message_id| (get-message-id message))))
-    (when disable-notification (nconc options `((:|disable_notification| . ,disable-notification))))
+         (append (list :|chat_id| (get-chat-id chat)
+                       :|from_chat_id| (get-chat-id from-chat)
+                       :|message_id| (get-message-id message))
+                 (when disable-notification
+                   (list :|disable_notification| t)))))
     (make-request bot "forwardMessage" options)))
 
 ;; TODO: refactor


### PR DESCRIPTION
This adds `delete-message` binding.

As a consequence of that, I've added the `id` slot required for `delete-message`.

I've
- Compiled `cl-telegram-bot` with this change.
- Tested the `delete-message` working in my bot.
- Checked message objects for IDs.

Looks fine to you, @svetlyak40wt?