### PR TITLE
Support for more chat types

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,13 @@
  ChangeLog
 ===========
 
+0.3.2 (2022-07-10)
+==================
+
+* Add ``id`` slot to ``message``; add ``forward-message``, ``delete-message`` functions reliant on ``id``.
+* Add more ``message`` types: ``reply``, ``forwarded``.
+* Add more ``chat`` types: ``group``, ``supergroup``, and ``channel``.
+
 0.3.1 (2020-01-04)
 ==================
 

--- a/src/chat.lisp
+++ b/src/chat.lisp
@@ -108,10 +108,7 @@
                       (t 'private-chat)))))
            (slots (mapcar (alexandria:compose #'first #'closer-mop:slot-definition-initargs)
                           (closer-mop:class-slots class)))
-           (underscored-slots
-             (mapcar (lambda (slot)
-                       (intern (cffi:translate-underscore-separated-name slot) :keyword))
-                     slots)))
+           (underscored-slots (mapcar #'kebab:to-snake-case slots)))
       (apply #'make-instance
              class
              (alexandria:mappend

--- a/src/chat.lisp
+++ b/src/chat.lisp
@@ -3,8 +3,7 @@
   (:import-from #:closer-mop
                 #:class-slots
                 #:slot-definition-initargs)
-  (:import-from #:cffi
-                #:translate-underscore-separated-name)
+  (:import-from #:kebab)
   (:import-from #:cl-telegram-bot/network
                 #:make-request)
   (:import-from #:cl-telegram-bot/telegram-call

--- a/src/message.lisp
+++ b/src/message.lisp
@@ -33,7 +33,6 @@
    #:get-forward-sender-name
    #:forwarded
    #:on-message
-   #:reply
    #:get-current-chat))
 (in-package cl-telegram-bot/message)
 
@@ -65,7 +64,7 @@
 (defclass forwarded (message)
   ((forward-from :initarg :forward-from
                  :reader get-forward-from)
-   (forward-sender-name :initarg :forwarded-sender-name
+   (forward-sender-name :initarg :forward-sender-name
                         :reader get-forward-sender-name)
    (forward-from-chat :initarg :forward-from-chat
                       :reader get-forward-from-chat)))


### PR DESCRIPTION
This adds more chat types, notably `group`, `supergroup`, and `channel`, with their respective slots. Given the new things introduced in #10, message processing was broken, and this fixes it.

This also fixes an exported symbol duplication and an initarg name in message.lisp, introduced in #10.