### PR TITLE
Send files via pathanmes

### DIFF
--- a/src/message.lisp
+++ b/src/message.lisp
@@ -394,7 +394,6 @@ https://core.telegram.org/bots/api#sendphoto"
   (apply #'make-request bot "sendPhoto"
          :|chat_id| (get-chat-id chat)
          :|photo| photo
-	 :pathname-p t
          options))
 
 (defmethod send-audio (bot chat (audio string)

--- a/src/message.lisp
+++ b/src/message.lisp
@@ -355,8 +355,6 @@ the file.")
                          allow-sending-without-reply reply-markup)
   "A method for photo sending based on photo ID.
 
-The file-based method does not work yet.
-
 https://core.telegram.org/bots/api#sendphoto"
   (declare (ignorable caption parse-mode caption-entities
                       disable-notification protect-content reply-to-message-id
@@ -380,6 +378,24 @@ https://core.telegram.org/bots/api#sendphoto"
                       allow-sending-without-reply reply-markup))
   (log:debug "Sending photo" chat (get-file-name photo))
   (apply #'send-photo bot chat (get-file-id photo) options))
+
+(defmethod send-photo (bot chat (photo pathname)
+                       &rest options
+                       &key caption parse-mode caption-entities
+                         disable-notification protect-content reply-to-message-id
+                         allow-sending-without-reply reply-markup)
+  "A method for photo sending based on pathname.
+
+https://core.telegram.org/bots/api#sendphoto"
+  (declare (ignorable caption parse-mode caption-entities
+                      disable-notification protect-content reply-to-message-id
+                      allow-sending-without-reply reply-markup))
+  (log:debug "Sending photo" chat photo)
+  (apply #'make-request bot "sendPhoto"
+         :|chat_id| (get-chat-id chat)
+         :|photo| photo
+	 :pathname-p t
+         options))
 
 (defmethod send-audio (bot chat (audio string)
                        &rest options

--- a/src/network.lisp
+++ b/src/network.lisp
@@ -23,9 +23,21 @@
   (:report (lambda (condition stream)
              (format stream "Request error: ~A" (what condition)))))
 
+(defun process-options (&rest options &key (pathname-p nil) &allow-other-keys)
+  (loop for (key value)
+          on (alexandria:remove-from-plist options :timeout :streamp :pathname-p)
+	by #'cddr
+	when value
+	  if pathname-p
+	    collect (cons (kebab:to-snake-case key) value)
+	else
+	  collect (kebab:to-snake-case key)
+	  and
+            collect value))
 
-(defun make-request (bot name &rest options &key (streamp nil) (timeout 3) &allow-other-keys)
-  "Perform HTTP request to 'name API method with 'options JSON-encoded object."
+
+(defun make-request (bot name &rest options &key (streamp nil) (timeout 3) (pathname-p nil) &allow-other-keys)
+  "Perform HTTP request to 'name API method with 'options JSON-encoded object or multi-part form-data."
   (declare (ignore streamp))
 
   (let ((url (concatenate 'string (get-endpoint bot) name)))
@@ -33,26 +45,14 @@
                (obfuscate url)
                options)
     (let* ((max-timeout (* timeout 10))
-           (processed-options (loop for (key value)
-                                      on (alexandria:remove-from-plist options :timeout :streamp)
-                                        by #'cddr
-                                    when value
-                                      collect (kebab:to-snake-case key)
-                                      and
-                                        collect value))
+           (processed-options (apply #'process-options options))
            (response
-             (if *proxy*
-                 (dexador:post url
-                               :headers '(("Content-Type" . "application/json"))
-                               :content (jonathan:to-json processed-options)
-                               :read-timeout max-timeout
-                               :connect-timeout max-timeout
-                               :proxy *proxy*)
-                 (dexador:post url
-                               :headers '(("Content-Type" . "application/json"))
-                               :content (jonathan:to-json processed-options)
-                               :read-timeout max-timeout
-                               :connect-timeout max-timeout)))
+             (dexador:post url
+                           :headers (unless pathname-p '(("Content-Type" . "application/json")))
+                           :content (if pathname-p processed-options (jonathan:to-json processed-options))
+                           :read-timeout max-timeout
+                           :connect-timeout max-timeout
+                           :proxy (if *proxy* *proxy* dex:*default-proxy*)))
            (data (jonathan:parse response)))
       (unless (getf data :|ok|)
         (log:error "Wrong data received from the server" data)


### PR DESCRIPTION
Dexador can automatically create multi-part post requests when given pathnames in content.
